### PR TITLE
feat: split PDFs into size-limited parts

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,11 @@
       </div>
 
       <!-- Botão para selecionar os arquivos -->
-      <button id="selectFilesBtn">Carregar Arquivos</button>
-      <!-- Input oculto para seleção de múltiplos arquivos -->
-      <input type="file" id="fileInput" multiple accept=".pdf, .png, .jpg, .jpeg" style="display: none;" />
+        <button id="selectFilesBtn">Carregar Arquivos</button>
+        <!-- Input oculto para seleção de múltiplos arquivos -->
+        <input type="file" id="fileInput" multiple accept=".pdf, .png, .jpg, .jpeg" style="display: none;" />
+        <!-- Botão para diminuir PDFs -->
+        <button id="compressPdfBtn">Diminuir PDF</button>
 
       <!-- Container para exibir mensagens de feedback -->
       <div id="feedbackContainer"></div>
@@ -37,6 +39,17 @@
       </div>
     </div>
 
+    <!-- Modal para diminuir PDF -->
+    <div id="compressModal" class="modal">
+      <div class="modal-content">
+        <span id="closeCompressModal" class="close">&times;</span>
+        <h2>Diminuir PDF</h2>
+        <input type="file" id="compressFileInput" accept=".pdf" />
+        <input type="number" id="maxSizeInput" placeholder="Tamanho máximo (MB)" />
+        <button id="confirmCompressBtn">Confirmar</button>
+      </div>
+    </div>
+
     <!-- Rodapé da página -->
     <div class="footer">
       Gerencia de TI do Hospital Português. Versão 3.1
@@ -44,6 +57,7 @@
 
     <!-- Inclusão das bibliotecas necessárias -->
     <script src="https://unpkg.com/pdf-lib@1.17.1/dist/pdf-lib.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,12 @@ const fileInput = document.getElementById("fileInput");
 const feedbackContainer = document.getElementById("feedbackContainer");
 const groupsContainer = document.getElementById("groupsContainer");
 const completedList = document.getElementById("completedList");
+const compressPdfBtn = document.getElementById("compressPdfBtn");
+const compressModal = document.getElementById("compressModal");
+const closeCompressModal = document.getElementById("closeCompressModal");
+const confirmCompressBtn = document.getElementById("confirmCompressBtn");
+const compressFileInput = document.getElementById("compressFileInput");
+const maxSizeInput = document.getElementById("maxSizeInput");
 
 // Variável isFolderMode (pode ser removida se não for utilizada)
 let isFolderMode = true;
@@ -21,6 +27,32 @@ selectFilesBtn.addEventListener("click", () => {
 
 // Ao selecionar arquivos, processa a seleção
 fileInput.addEventListener("change", handleFileSelection);
+
+// Eventos do modal de diminuição de PDF
+compressPdfBtn.addEventListener("click", () => {
+  compressModal.style.display = "block";
+});
+
+closeCompressModal.addEventListener("click", () => {
+  compressModal.style.display = "none";
+});
+
+window.addEventListener("click", (e) => {
+  if (e.target === compressModal) {
+    compressModal.style.display = "none";
+  }
+});
+
+confirmCompressBtn.addEventListener("click", async () => {
+  const file = compressFileInput.files[0];
+  const maxSize = parseFloat(maxSizeInput.value);
+  if (!file || isNaN(maxSize) || maxSize <= 0) {
+    showFeedback("Selecione um arquivo PDF e informe o tamanho máximo.", "error");
+    return;
+  }
+  compressModal.style.display = "none";
+  await splitPdfBySize(file, maxSize);
+});
 
 function handleFileSelection() {
   clearFeedback();
@@ -274,6 +306,63 @@ async function previewMergedPDF() {
     showFeedback("Pré-visualização atualizada com sucesso!", "success");
   } catch (err) {
     showFeedback("Erro ao gerar pré-visualização.", "error");
+    console.error(err);
+  }
+}
+
+// Função para dividir PDF em partes com tamanho máximo
+async function splitPdfBySize(file, maxSizeMB) {
+  try {
+    const maxBytes = maxSizeMB * 1024 * 1024;
+    const arrayBuffer = await file.arrayBuffer();
+    const pdf = await PDFLib.PDFDocument.load(arrayBuffer);
+    const totalPages = pdf.getPageCount();
+    const baseName = file.name.replace(/\.pdf$/i, "");
+    const zip = new JSZip();
+    let part = 1;
+    let currentPdf = await PDFLib.PDFDocument.create();
+
+    for (let i = 0; i < totalPages; i++) {
+      const [copiedPage] = await currentPdf.copyPages(pdf, [i]);
+      currentPdf.addPage(copiedPage);
+      const currentBytes = await currentPdf.save();
+
+      if (currentBytes > maxBytes) {
+        currentPdf.removePage(currentPdf.getPageCount() - 1);
+        if (currentPdf.getPageCount() > 0) {
+          const chunkBytes = await currentPdf.save();
+          zip.file(`${baseName}-parte${part}.pdf`, chunkBytes);
+          part++;
+        }
+
+        const newDoc = await PDFLib.PDFDocument.create();
+        const [singlePage] = await newDoc.copyPages(pdf, [i]);
+        newDoc.addPage(singlePage);
+        const singleBytes = await newDoc.save();
+        if (singleBytes > maxBytes) {
+          showFeedback(`A página ${i + 1} excede o limite de ${maxSizeMB} MB.`, "error");
+          return;
+        }
+        currentPdf = newDoc;
+      }
+    }
+
+    if (currentPdf.getPageCount() > 0) {
+      const bytes = await currentPdf.save();
+      zip.file(`${baseName}-parte${part}.pdf`, bytes);
+    }
+
+    const zipBlob = await zip.generateAsync({ type: "blob" });
+    const url = URL.createObjectURL(zipBlob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${baseName}_dividido.zip`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    showFeedback("PDF dividido com sucesso! Download iniciado.", "success");
+  } catch (err) {
+    showFeedback("Erro ao dividir o PDF.", "error");
     console.error(err);
   }
 }

--- a/style.css
+++ b/style.css
@@ -177,14 +177,51 @@ button:hover {
 }
 
 /* Rodapé */
-.footer {
-  text-align: center;
-  padding: 15px;
-  background-color: #007bff;
-  color: #fff;
-  margin-top: 40px;
-  font-size: 1rem;
-}
+  .footer {
+    text-align: center;
+    padding: 15px;
+    background-color: #007bff;
+    color: #fff;
+    margin-top: 40px;
+    font-size: 1rem;
+  }
+
+  /* Modal para diminuir PDF */
+  .modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.4);
+  }
+
+  .modal-content {
+    background-color: #fff;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 400px;
+    border-radius: 8px;
+  }
+
+  .modal-content input {
+    width: 100%;
+    margin: 10px 0;
+    padding: 8px;
+  }
+
+  .modal .close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+  }
 
 /* Responsividade */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add **Diminuir PDF** button and modal for specifying max size
- implement client-side PDF splitting by size using pdf-lib and JSZip
- package resulting parts into zip and download automatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b8ab8528832eb0fb14f82eea271d